### PR TITLE
add a set of default keys for the remote control

### DIFF
--- a/remote.json
+++ b/remote.json
@@ -3,7 +3,19 @@
   "BTN_DPAD_UP": ["press", ["media_volume_up"]],
   "BTN_DPAD_LEFT": ["press", ["shift", 269025027]],
   "BTN_DPAD_DOWN": ["press", ["media_volume_down"]],
+
+  "BTN_WEST": ["press", ["i", "f", "esc"]],
+  "BTN_EAST": ["press", ["i", "space", "esc"]],
+
+  "BTN_TL": ["press", ["i", "shift", "p", "esc"]],
+  "BTN_TR": ["press", ["i", "shift", "n", "esc"]],
+  "BTN_TL2": ["press", ["i", "left", "esc"]],
+  "BTN_TR2": ["press", ["i", "right", "esc"]],
+
+  "BTN_MODE": ["press", ["esc"]],
+
   "BTN_SOUTH": ["click", "left"],
+
   "ABS_X": ["move", "x"],
   "ABS_Y": ["move", "y"]
 }


### PR DESCRIPTION
This PR adds a set of default keys and bindings to be used in a remote emulation with a PS3 controller.