### PR TITLE
FIX: add missing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ evdev==1.6.0
 pynput==1.7.6
 pre-commit==2.20.0
 rich==12.5.1
+keyboard==0.13.5
+mouse==0.7.1


### PR DESCRIPTION
This PR adds missing dependencies, namely `keyboard` and `mouse` to control the devices.