### PR TITLE
FEATURE: support multiple profiles

### DIFF
--- a/remote.json
+++ b/remote.json
@@ -1,21 +1,59 @@
 {
-  "BTN_DPAD_RIGHT": ["press", ["shift", 269025026]],
-  "BTN_DPAD_UP": ["press", ["media_volume_up"]],
-  "BTN_DPAD_LEFT": ["press", ["shift", 269025027]],
-  "BTN_DPAD_DOWN": ["press", ["media_volume_down"]],
+    "qutebrowser": {
+        "BTN_DPAD_RIGHT": ["press", ["shift", 269025026]],
+        "BTN_DPAD_UP": ["press", ["media_volume_up"]],
+        "BTN_DPAD_LEFT": ["press", ["shift", 269025027]],
+        "BTN_DPAD_DOWN": ["press", ["media_volume_down"]],
 
-  "BTN_WEST": ["press", ["i", "f", "esc"]],
-  "BTN_EAST": ["press", ["i", "space", "esc"]],
+        "BTN_WEST": ["press", ["i", "f", "esc"]],
+        "BTN_EAST": ["press", ["i", "space", "esc"]],
 
-  "BTN_TL": ["press", ["i", "shift", "p", "esc"]],
-  "BTN_TR": ["press", ["i", "shift", "n", "esc"]],
-  "BTN_TL2": ["press", ["i", "left", "esc"]],
-  "BTN_TR2": ["press", ["i", "right", "esc"]],
+        "BTN_TL": ["press", ["i", "shift", "p", "esc"]],
+        "BTN_TR": ["press", ["i", "shift", "n", "esc"]],
+        "BTN_TL2": ["press", ["i", "left", "esc"]],
+        "BTN_TR2": ["press", ["i", "right", "esc"]],
 
-  "BTN_MODE": ["press", ["esc"]],
+        "BTN_MODE": ["press", ["esc"]],
 
-  "BTN_SOUTH": ["click", "left"],
+        "BTN_SOUTH": ["click", "left"],
 
-  "ABS_X": ["move", "x"],
-  "ABS_Y": ["move", "y"]
+        "ABS_X": ["move", "x"],
+        "ABS_Y": ["move", "y"]
+    },
+    "firefox": {
+        "BTN_DPAD_RIGHT": ["press", ["shift", 269025026]],
+        "BTN_DPAD_UP": ["press", ["media_volume_up"]],
+        "BTN_DPAD_LEFT": ["press", ["shift", 269025027]],
+        "BTN_DPAD_DOWN": ["press", ["media_volume_down"]],
+
+        "BTN_WEST": ["press", ["f"]],
+        "BTN_EAST": ["press", ["space"]],
+
+        "BTN_TL2": ["press", ["left"]],
+        "BTN_TR2": ["press", ["right"]],
+
+        "BTN_SOUTH": ["click", "left"],
+
+        "ABS_X": ["move", "x"],
+        "ABS_Y": ["move", "y"]
+    },
+    "mpv": {
+        "BTN_DPAD_RIGHT": ["press", ["shift", 269025026]],
+        "BTN_DPAD_UP": ["press", ["media_volume_up"]],
+        "BTN_DPAD_LEFT": ["press", ["shift", 269025027]],
+        "BTN_DPAD_DOWN": ["press", ["media_volume_down"]],
+
+        "BTN_WEST": ["press", ["f"]],
+        "BTN_EAST": ["press", ["space", "o"]],
+
+        "BTN_TL": ["press", ["<", "i"]],
+        "BTN_TR": ["press", [">", "i"]],
+        "BTN_TL2": ["press", ["left", "o"]],
+        "BTN_TR2": ["press", ["right", "o"]],
+
+        "BTN_SOUTH": ["click", "left"],
+
+        "ABS_X": ["move", "x"],
+        "ABS_Y": ["move", "y"]
+    }
 }

--- a/remote.py
+++ b/remote.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import json
+import argparse
 from typing import Dict
 
 import evdev
@@ -9,13 +10,33 @@ from rich import print
 from src import device, hooks
 
 
-def main():
+def main(*, profile: str):
     with open("remote.json", "r") as remote_config_file:
-        config = json.load(remote_config_file)
+        config = json.load(remote_config_file)[profile]
 
     configured_remote_hook = lambda s: hooks.remote_hook(s, config=config)
     device.listen_to(device.get_device(), hook=configured_remote_hook)
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser()
+
+    profiles = ["qutebrowser", "mpv", "firefox"]
+    parser.add_argument(
+        "--profile",
+        "-p",
+        choices=profiles,
+        required=True,
+        help=(
+            "A different profile will send different keys to "
+            "the host machine, e.g. `qutebrowser` requires to "
+            "enter insert mode with 'i' and exit it afterwards "
+            "with <esc>, 'firefox' and 'mpv' do not."
+            "`mpv` was designed to watch local videos. "
+            "`qutebrowser` for youtube in mind only. "
+            "and `firefox` for all the rest (netflix, primevideos, ...)"
+        )
+    )
+
+    args = parser.parse_args()
+    main(profile=args.profile)


### PR DESCRIPTION
This PR adds a support for multiple profiles and thus multiple applications.
The goal is to have the same interface on the controller but different key presses sent to the applications.
This is controlled from `remote.json` and with the `--profile` flag.