### PR TITLE
FEATURE: add multi-presses support

### DIFF
--- a/remote.json
+++ b/remote.json
@@ -1,8 +1,8 @@
 {
     "common": {
-        "BTN_DPAD_RIGHT": ["press", ["shift", 269025026]],
+        "BTN_DPAD_RIGHT": ["press", [["shift", 269025026]]],
         "BTN_DPAD_UP": ["press", ["media_volume_up"]],
-        "BTN_DPAD_LEFT": ["press", ["shift", 269025027]],
+        "BTN_DPAD_LEFT": ["press", [["shift", 269025027]]],
         "BTN_DPAD_DOWN": ["press", ["media_volume_down"]],
 
         "BTN_MODE": ["profile", ""],
@@ -18,8 +18,8 @@
             "BTN_WEST": ["press", ["i", "f", "esc"]],
             "BTN_EAST": ["press", ["i", "space", "esc"]],
 
-            "BTN_TL": ["press", ["i", "shift", "p", "esc"]],
-            "BTN_TR": ["press", ["i", "shift", "n", "esc"]],
+            "BTN_TL": ["press", ["i", ["shift", "p"], "esc"]],
+            "BTN_TR": ["press", ["i", ["shift", "n"], "esc"]],
             "BTN_TL2": ["press", ["i", "left", "esc"]],
             "BTN_TR2": ["press", ["i", "right", "esc"]]
         },

--- a/src/computer.py
+++ b/src/computer.py
@@ -22,6 +22,14 @@ def convert_action_to_key(action: Union[str, int]):
     return key
 
 
+def convert_action_to_keys(action: Union[str, int]):
+    if isinstance(action, list):
+        keys = [convert_action_to_key(el) for el in action]
+    else:
+        keys = [convert_action_to_key(action)]
+    return keys
+
+
 def cycle_through_profiles(arg: str, kwargs: Dict[str, Any]) -> str:
     profile = kwargs["profile"]
     idx = utils.PROFILES.index(profile)
@@ -31,15 +39,20 @@ def cycle_through_profiles(arg: str, kwargs: Dict[str, Any]) -> str:
     return new_profile
 
 
-def send_keyboard_press(
-    actions: List[Union[str, int]], *, kwargs: Dict[str, Any]
-) -> None:
-    keys = [convert_action_to_key(action) for action in actions]
+def send_keyboard_press(keys) -> None:
     for key in keys:
         keyboard.press(key)
 
     for key in keys[::-1]:
         keyboard.release(key)
+
+
+def send_keyboard_presses(
+    actions: List[Union[str, int]], *, kwargs: Dict[str, Any]
+) -> None:
+    all_keys = [convert_action_to_keys(action) for action in actions]
+    for keys in all_keys:
+        send_keyboard_press(keys)
 
 
 def send_mouse_click(action: str, *, kwargs: Dict[str, Any]) -> None:
@@ -57,7 +70,7 @@ def send_mouse_move(action: str, *, kwargs: Dict[str, Any]) -> None:
 
 ACTIONS = {
     "profile": cycle_through_profiles,
-    "press": send_keyboard_press,
+    "press": send_keyboard_presses,
     "click": send_mouse_click,
     "move": send_mouse_move,
 }


### PR DESCRIPTION
This PR adds an extra layer of key processing to allow the user to encode multiple presses.

For instance, a config file could have the form:
```json
{
    "common": {
        "BTN": ["press", ["single_press"]],
        "OTHER": ["press", ["other_single_press", ["multipress_1", "multipress_2"]]]
    }
}
```
and `"single_press"` would send a single press to the keyboard, whereas `["other_single_press", ["multipress_1", "multipress_2"]]` would send a single press and then a combination of keys to the keyboard.