### PR TITLE
FEATURE: add install and clean scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # remote-ps3
 A remote emulator for a linux-ps3 system.
+
+## Usage
+- edit the `config.sh` file to change the name of the command and the paths
+- run `./install.sh` to
+  - install a `python` virtual environment with `virtualenv`
+  - install the dependencies from `requirements.txt` inside it
+  - build an executable script which runs the source
+  - move this script to some location in the `$PATH`
+- run `./clean.sh` to
+  - remove the virtual environment
+  - remove the executable from the `$PATH`
+  - remove the executable from the source

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+source config.sh
+
+if [ -d "$venv" ]; then
+  $RM -rf "$venv"
+else
+  echo "$venv is not installed..."
+fi
+
+if [ -f "$bin/$exe" ]; then
+  $RM "$bin/$exe"
+else
+  echo "$bin/$exe is not installed..."
+fi
+
+if [ -f "$exe" ]; then
+  $RM "$exe"
+else
+  echo "$exe not built..."
+fi

--- a/config.sh
+++ b/config.sh
@@ -1,5 +1,5 @@
 venv="$VIRTUALENVWRAPPER_HOOK_DIR/remote-PS3"
-exe="remote"
+exe="remote-PS3"
 bin="$HOME/.local/bin"
 
 RM="rm --verbose"

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,5 @@
+venv="$VIRTUALENVWRAPPER_HOOK_DIR/remote-PS3"
+exe="remote"
+bin="$HOME/.local/bin"
+
+RM="rm --verbose"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+source config.sh
+
+if [ ! -d "$venv" ]; then
+  echo "not installed..."
+  echo "installing..."
+  virtualenv "$venv"
+  source "$venv/bin/activate"
+  pip install -r requirements.txt
+  echo "installation done!"
+else
+  echo "already installed!"
+fi
+
+path=$(pwd)
+
+cat << EOF > "$exe"
+#!/usr/bin/env bash
+source $venv/bin/activate
+python $path/remote.py
+EOF
+
+chmod +x "$exe"
+cp "$exe" "$bin"

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ path=$(pwd)
 cat << EOF > "$exe"
 #!/usr/bin/env bash
 source $venv/bin/activate
-python $path/remote.py
+python $path/remote.py --config $path/remote.json
 EOF
 
 chmod +x "$exe"


### PR DESCRIPTION
This PR adds two scripts and a config script to:
- install the remote application to `~/.local/bin` by default with `./install.sh`
- clean the generated files with `./clean.sh`