### PR TITLE
FIX: do not install the package in development mode

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,7 +9,7 @@ if [ ! -d "$venv" ]; then
   virtualenv "$venv"
   source "$venv/bin/activate"
   pip install -r requirements.txt
-  pip install -e .
+  pip install .
   echo "installation of ${cyan}$venv${end} is ${green}successful${end}!"
 else
   echo "${cyan}$venv${end}is ${yellow}already installed${end}!"


### PR DESCRIPTION
This PR makes sure the `remote` package is not installed in development mode.

This avoids the executable to break whenever the source is changed, but rather require to `scripts/clean.sh` and `scripts/install.sh` again :+1: 