### PR TITLE
FIX: install the executable and the libraries

### DIFF
--- a/config/install.sh
+++ b/config/install.sh
@@ -2,5 +2,6 @@ venv="$VIRTUALENVWRAPPER_HOOK_DIR/remote-PS3"
 exe="remote-PS3"
 build="build"
 bin="$HOME/.local/bin"
+lib="$XDG_DATA_HOME/remote-PS3"
 
 RM="rm --verbose"

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -23,3 +23,10 @@ if [ -f "$build/$exe" ]; then
 else
   echo "${cyan}$build/$exe${end} is ${red}not built${end}..."
 fi
+
+if [ -d "$lib" ]; then
+  echo "${yellow}removing ${cyan}$lib${end}!"
+  $RM --recursive "$lib"
+else
+  echo "${cyan}$lib${end} is ${red}not built${end}..."
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,17 +15,22 @@ else
   echo "${cyan}$venv${end}is ${yellow}already installed${end}!"
 fi
 
-path=$(pwd)
-
 cat << EOF > "$exe"
 #!/usr/bin/env bash
 source $venv/bin/activate
-python $path/scripts/run.py --config $path/config/remote.json
+python $lib/run --config $lib/config.json
 EOF
 
 chmod +x "$exe"
 cp "$exe" "$bin" --verbose
+
 if [ ! -d "$build" ]; then
   mkdir "$build"
 fi
 mv "$exe" "$build" --verbose
+
+if [ ! -d "$lib" ]; then
+  mkdir "$lib"
+fi
+cp scripts/run.py "$lib/run" --verbose
+cp config/remote.json "$lib/config.json" --verbose


### PR DESCRIPTION
This PR installs the run script and the config `JSON` file to `~/.local/share/remote-PS3` to stop relying on the source repository.
with this PR, the `~/.local/bin/remote-PS3` executable can run without the source being even on the disk locally, allowing to get rid of the source or develop things without breaking the installed `remote-PS3` executable, virtual `python` environment and libraries.